### PR TITLE
fix: enable panning left in pan mode

### DIFF
--- a/page_json.html
+++ b/page_json.html
@@ -24,6 +24,8 @@
     .zoom-wrap input[type="range"] { width: 160px; }
 
     .stage { display: grid; place-content: start center; padding: 1rem; padding-top: calc(var(--header-h) + 1rem); }
+    /* Align content to top-left when panning so horizontal dragging works in both directions */
+    body.pan .stage { place-content: start; }
     .page-outer { position: relative; }
     .page-wrap { position: relative; transform-origin: top left; }
     .page-wrap img { width: 100%; height: auto; display: block; box-shadow: 0 10px 30px rgba(0,0,0,.45); border-radius: .5rem; }


### PR DESCRIPTION
## Summary
- allow horizontal dragging in both directions by left-aligning stage when pan mode is active

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6f1603f3c8329a57267bb6d5b6776