### PR TITLE
Remove query string from citation URL

### DIFF
--- a/page_json.php
+++ b/page_json.php
@@ -290,7 +290,8 @@ $docJson = json_encode($docData, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | 
         year = match[1];
       }
     }
-    const url = window.location.href;
+    const { origin, pathname, hash } = window.location;
+    const url = `${origin}${pathname}${hash ?? ''}`;
     const now = new Date();
     const accessed = now.toLocaleDateString('en-GB', {
       day: 'numeric',


### PR DESCRIPTION
## Summary
- update the citation formatter in page_json.php to build the page URL without any query string parameters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ca6b5f2d148329826a8a5cf74f3f42