### PR TITLE
Convert page viewer to PHP with DB navigation

### DIFF
--- a/index2.php
+++ b/index2.php
@@ -714,8 +714,8 @@ if (!empty($results)) {
 
 
               // 3) Build your link with proper encoding of the query params
-              $hrefILN = '/semantic/page_json.html?' . http_build_query([
-                'page' =>  '/' . ($row['journal'] ?? '') . '/' . ($row['issue'] ?? '') . '/pages/page-000' . ($row['first_page'] ?? ''),
+              $hrefILN = '/semantic/page_json.php?' . http_build_query([
+                'page' =>  (string)($row['id'] ?? ''),
                 'q'    => $csv,
               ]);
 


### PR DESCRIPTION
## Summary
- convert the static page viewer into `page_json.php` that resolves page metadata from Postgres using the requested document id
- embed next/previous navigation ids and asset paths in the page payload so the client can fetch the JSON/text overlay and images directly
- update `index2.php` search results to link to the new PHP endpoint using the document id

## Testing
- php -l page_json.php
- php -l index2.php

------
https://chatgpt.com/codex/tasks/task_e_68cbe224fcf083299b1c1d2d5cee56a9