### PR TITLE
Fix page asset paths without doc journal

### DIFF
--- a/index2.php
+++ b/index2.php
@@ -718,12 +718,19 @@ if (!empty($results)) {
               // 3) Build your link with proper encoding of the query params
               $pageId = $row['page_id'] ?? null;
               $hasPageId = $pageId !== null && $pageId !== '';
-              $hrefILN = $hasPageId
-                  ? '/semantic/page_json.php?' . http_build_query([
+              if ($hasPageId) {
+                  $pageLinkParams = [
                       'page_id' => (string)$pageId,
                       'q'       => $csv,
-                    ])
-                  : null;
+                  ];
+                  $journalParam = $row['journal'] ?? null;
+                  if (is_string($journalParam) && $journalParam !== '') {
+                      $pageLinkParams['journal'] = $journalParam;
+                  }
+                  $hrefILN = '/semantic/page_json.php?' . http_build_query($pageLinkParams);
+              } else {
+                  $hrefILN = null;
+              }
 
               $thumbLinkAttrs = $hasPageId
                   ? ' target="_blank" rel="noopener"'


### PR DESCRIPTION
## Summary
- include journal fallback metadata in page_json.php query
- allow passing journal via query parameter when metadata is missing
- add journal to page_json links generated in index2.php

## Testing
- php -l page_json.php
- php -l index2.php

------
https://chatgpt.com/codex/tasks/task_e_68cbff4f5eb88329b4f9fa00e15065bd