### PR TITLE
Align Claude prompt metadata with issue/date mapping

### DIFF
--- a/prompt_claud.md
+++ b/prompt_claud.md
@@ -10,8 +10,8 @@ You will receive one or more article blocks in markdown, already normalized. Eac
 Use the exact ID value (the line immediately under the title).
 
 Grounding metadata (treat as facts):
-Newspaper: Illustrated London News
-Issue\_Date: 1850-01-05 (ground truth)
+Newspaper: {{NEWSPAPER}}
+Issue\_Date: {{ISSUE_DATE}}
 Place: London, United Kingdom
 
 Do not repeat the title, summary, or any other fields from the article.


### PR DESCRIPTION
## Summary
- map the docs.issue column to the newspaper metadata passed to Claude and rely on the date column for the issue date, with a ground-truth fallback
- simplify the Claude system prompt template to request only the newspaper (issue) and issue date values

## Testing
- php -l historical_context.php

------
https://chatgpt.com/codex/tasks/task_e_68cd0b4ca6f483298f0c64f6f6f47ac9