### PR TITLE
Add search heatmap over time and supporting indexes

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -338,6 +338,27 @@ CREATE INDEX docs_date_page_id_idx ON public.docs USING btree (date, page, id);
 
 
 --
+-- Name: docs_date_idx; Type: INDEX; Schema: public; Owner: journal_user
+--
+
+CREATE INDEX IF NOT EXISTS docs_date_idx ON public.docs USING btree (date);
+
+
+--
+-- Name: docs_year_month_idx; Type: INDEX; Schema: public; Owner: journal_user
+--
+
+CREATE INDEX IF NOT EXISTS docs_year_month_idx ON public.docs USING btree (date_trunc('month', date));
+
+
+--
+-- Name: docs_pub_date_idx; Type: INDEX; Schema: public; Owner: journal_user
+--
+
+CREATE INDEX IF NOT EXISTS docs_pub_date_idx ON public.docs USING btree (pubname, date);
+
+
+--
 -- Name: docs_embedding_hnsw_hv; Type: INDEX; Schema: public; Owner: journal_user
 --
 


### PR DESCRIPTION
## Summary
- add server-side heatmap scoring endpoint with caching, PG SQL helpers, and AJAX handler
- extend search page with time range controls, heatmap visualization, and modal for top results
- include additional Postgres indexes for docs table date filters

## Testing
- php -l index2.php

------
https://chatgpt.com/codex/tasks/task_e_68cfd10ac6fc832980924e685c43d5d1