### PR TITLE
Add interactive click-to-confirm helpers

### DIFF
--- a/theme_drift.php
+++ b/theme_drift.php
@@ -57,6 +57,33 @@ function parse_vector_text(?string $text): array
     return $out;
 }
 
+function fetch_period_row(PDO $pdo, string $period, string $periodKey, bool $isCombined, ?string $pubname): ?array
+{
+    $sql = "SELECT id, period, period_key, period_start::text AS period_start, period_end::text AS period_end, pubname, is_combined FROM public.period_embeddings WHERE period = :period AND period_key = :period_key AND is_combined = :is_combined";
+    if (!$isCombined) {
+        $sql .= " AND pubname = :pubname";
+    }
+    $sql .= " LIMIT 1";
+
+    $stmt = $pdo->prepare($sql);
+    $stmt->bindValue(':period', $period, PDO::PARAM_STR);
+    $stmt->bindValue(':period_key', $periodKey, PDO::PARAM_STR);
+    $stmt->bindValue(':is_combined', $isCombined, PDO::PARAM_BOOL);
+    if (!$isCombined) {
+        $stmt->bindValue(':pubname', $pubname, PDO::PARAM_STR);
+    }
+    $stmt->execute();
+
+    $row = $stmt->fetch();
+    if ($row === false) {
+        return null;
+    }
+
+    $row['id'] = isset($row['id']) ? (int)$row['id'] : null;
+
+    return $row;
+}
+
 $action = $_GET['action'] ?? '';
 
 if ($action === 'data') {
@@ -212,6 +239,166 @@ if ($action === 'data') {
     }
 }
 
+if ($action === 'nearest_docs' || $action === 'topic_labels' || $action === 'drift') {
+    try {
+        $period = $_GET['period'] ?? 'year';
+        $period = $period === 'month' ? 'month' : 'year';
+
+        $aggregation = $_GET['aggregation'] ?? 'combined';
+        $isCombined = $aggregation !== 'per_pub';
+
+        $pubname = null;
+        if (!$isCombined) {
+            $pubname = trim((string)($_GET['pubname'] ?? ''));
+            if ($pubname === '') {
+                respond_json(400, ['ok' => false, 'error' => 'Select a publication to continue.']);
+            }
+        }
+
+        $periodKey = trim((string)($_GET['period_key'] ?? ''));
+        if ($periodKey === '') {
+            respond_json(400, ['ok' => false, 'error' => 'Missing period key.']);
+        }
+
+        $pdo = pg_pdo($PGHOST, $PGPORT, $PGDATABASE, $PGUSER, $PGPASSWORD);
+        $periodRow = fetch_period_row($pdo, $period, $periodKey, $isCombined, $pubname);
+        if (!$periodRow || !isset($periodRow['id'])) {
+            respond_json(404, ['ok' => false, 'error' => 'Selected period not found.']);
+        }
+
+        $periodId = (int)$periodRow['id'];
+        $periodStart = $periodRow['period_start'] ?? null;
+        $periodEnd = $periodRow['period_end'] ?? null;
+
+        if ($action === 'nearest_docs') {
+            $limitRaw = $_GET['limit'] ?? '';
+            $limit = is_numeric($limitRaw) ? (int)$limitRaw : 10;
+            if ($limit < 1) {
+                $limit = 1;
+            }
+            if ($limit > 25) {
+                $limit = 25;
+            }
+
+            $sql = "SELECT d.id, d.pubname, d.date::text AS date, COALESCE(NULLIF(d.summary_clean, ''), NULLIF(d.summary_raw, ''), '') AS summary, 1 - (d.embedding_hv <=> p.embedding_hv) AS similarity FROM public.period_embeddings p JOIN public.docs d ON d.embedding_hv IS NOT NULL AND d.date IS NOT NULL AND d.date >= p.period_start AND d.date <= p.period_end AND (p.is_combined = true OR d.pubname = p.pubname) WHERE p.id = :id ORDER BY d.embedding_hv <=> p.embedding_hv ASC LIMIT :limit";
+            $stmt = $pdo->prepare($sql);
+            $stmt->bindValue(':id', $periodId, PDO::PARAM_INT);
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+            $stmt->execute();
+            $rows = $stmt->fetchAll();
+
+            $docs = [];
+            foreach ($rows as $row) {
+                $summary = (string)($row['summary'] ?? '');
+                $summary = trim($summary);
+                if (mb_strlen($summary) > 300) {
+                    $summary = mb_substr($summary, 0, 300) . '…';
+                }
+                $docs[] = [
+                    'id' => isset($row['id']) ? (int)$row['id'] : null,
+                    'pubname' => $row['pubname'] ?? null,
+                    'date' => $row['date'] ?? null,
+                    'summary' => $summary,
+                    'similarity' => isset($row['similarity']) ? (float)$row['similarity'] : null,
+                ];
+            }
+
+            respond_json(200, [
+                'ok' => true,
+                'count' => count($docs),
+                'period' => [
+                    'period_key' => $periodKey,
+                    'start' => $periodStart,
+                    'end' => $periodEnd,
+                ],
+                'docs' => $docs,
+            ]);
+        }
+
+        if ($action === 'topic_labels') {
+            $limitRaw = $_GET['limit'] ?? '';
+            $limit = is_numeric($limitRaw) ? (int)$limitRaw : 5;
+            if ($limit < 1) {
+                $limit = 1;
+            }
+            if ($limit > 15) {
+                $limit = 15;
+            }
+
+            $sql = "SELECT t.topic, 1 - (t.emb_hv <=> p.embedding_hv) AS similarity FROM public.period_embeddings p JOIN public.topic_labels t ON t.emb_hv IS NOT NULL WHERE p.id = :id ORDER BY t.emb_hv <=> p.embedding_hv ASC LIMIT :limit";
+            $stmt = $pdo->prepare($sql);
+            $stmt->bindValue(':id', $periodId, PDO::PARAM_INT);
+            $stmt->bindValue(':limit', $limit, PDO::PARAM_INT);
+            $stmt->execute();
+            $rows = $stmt->fetchAll();
+
+            $topics = [];
+            foreach ($rows as $row) {
+                $topics[] = [
+                    'topic' => $row['topic'] ?? null,
+                    'similarity' => isset($row['similarity']) ? (float)$row['similarity'] : null,
+                ];
+            }
+
+            respond_json(200, [
+                'ok' => true,
+                'count' => count($topics),
+                'period' => [
+                    'period_key' => $periodKey,
+                    'start' => $periodStart,
+                    'end' => $periodEnd,
+                ],
+                'topics' => $topics,
+            ]);
+        }
+
+        if ($action === 'drift') {
+            $sql = "SELECT prev.period_key AS prev_period_key, prev.period_start::text AS prev_start, prev.period_end::text AS prev_end, CASE WHEN prev.embedding_hv IS NOT NULL THEN (prev.embedding_hv <=> curr.embedding_hv) ELSE NULL END AS distance_to_prev, nxt.period_key AS next_period_key, nxt.period_start::text AS next_start, nxt.period_end::text AS next_end, CASE WHEN nxt.embedding_hv IS NOT NULL THEN (nxt.embedding_hv <=> curr.embedding_hv) ELSE NULL END AS distance_to_next FROM public.period_embeddings curr LEFT JOIN LATERAL ( SELECT period_key, period_start, period_end, embedding_hv FROM public.period_embeddings WHERE period = :period AND period_start < curr.period_start AND is_combined = curr.is_combined AND (:is_combined OR pubname = curr.pubname) ORDER BY period_start DESC LIMIT 1 ) AS prev ON true LEFT JOIN LATERAL ( SELECT period_key, period_start, period_end, embedding_hv FROM public.period_embeddings WHERE period = :period AND period_start > curr.period_start AND is_combined = curr.is_combined AND (:is_combined OR pubname = curr.pubname) ORDER BY period_start ASC LIMIT 1 ) AS nxt ON true WHERE curr.id = :id LIMIT 1";
+            $stmt = $pdo->prepare($sql);
+            $stmt->bindValue(':period', $period, PDO::PARAM_STR);
+            $stmt->bindValue(':is_combined', $isCombined, PDO::PARAM_BOOL);
+            $stmt->bindValue(':id', $periodId, PDO::PARAM_INT);
+            $stmt->execute();
+            $row = $stmt->fetch();
+
+            $prev = null;
+            if ($row && $row['prev_period_key'] !== null) {
+                $prev = [
+                    'period_key' => $row['prev_period_key'],
+                    'start' => $row['prev_start'],
+                    'end' => $row['prev_end'],
+                    'distance' => $row['distance_to_prev'] !== null ? (float)$row['distance_to_prev'] : null,
+                ];
+            }
+
+            $next = null;
+            if ($row && $row['next_period_key'] !== null) {
+                $next = [
+                    'period_key' => $row['next_period_key'],
+                    'start' => $row['next_start'],
+                    'end' => $row['next_end'],
+                    'distance' => $row['distance_to_next'] !== null ? (float)$row['distance_to_next'] : null,
+                ];
+            }
+
+            respond_json(200, [
+                'ok' => true,
+                'period' => [
+                    'period_key' => $periodKey,
+                    'start' => $periodStart,
+                    'end' => $periodEnd,
+                ],
+                'prev' => $prev,
+                'next' => $next,
+            ]);
+        }
+
+        respond_json(400, ['ok' => false, 'error' => 'Unsupported helper action.']);
+    } catch (Throwable $e) {
+        respond_json(500, ['ok' => false, 'error' => $e->getMessage()]);
+    }
+}
+
 $pdo = null;
 $pubnames = [];
 $rangeInfo = null;
@@ -355,53 +542,19 @@ if ($defaultStartYear > $defaultEndYear) {
             <div class="card shadow-sm mt-3">
                 <div class="card-body">
                     <h3 class="h6 mb-3">Click-to-confirm helpers</h3>
-                    <p class="small text-muted">Drop these snippets into a SQL client to jump from the visualization to the underlying records.</p>
-                    <div class="mb-4">
-                        <h4 class="h6">A) Inspect a month&rsquo;s nearest articles</h4>
-                        <p class="small text-muted">Swap <code>:key</code> for a <code>period_key</code> such as <code>&#039;1851-05&#039;</code>.</p>
-                    <pre class="bg-light p-3 small overflow-auto"><code>WITH m AS (
-  SELECT embedding_hv FROM public.period_embeddings
-  WHERE period = 'month' AND is_combined = TRUE AND period_key = :key
-)
-SELECT id, pubname, date, summary, (1 - d.embedding_hv &lt;=&gt; m.embedding_hv) AS sim
-FROM public.docs d, m
-WHERE date &gt;= to_date(:key || '-01', 'YYYY-MM-DD')
-  AND date &lt;  (to_date(:key || '-01', 'YYYY-MM-DD') + INTERVAL '1 month')
-ORDER BY d.embedding_hv &lt;=&gt; m.embedding_hv
-LIMIT 10;</code></pre>
+                    <p class="small text-muted" id="helperIntro">Select a point in the chart to unlock quick lookups.</p>
+                    <div class="d-grid gap-2 gap-sm-3 mb-3">
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="helperDocsButton" disabled>Show nearest articles</button>
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="helperTopicsButton" disabled>Suggest topic labels</button>
+                        <button type="button" class="btn btn-outline-primary btn-sm" id="helperDriftButton" disabled>Compare neighboring periods</button>
                     </div>
-                    <div class="mb-4">
-                        <h4 class="h6">B) Auto-label a month with curated topics</h4>
-                    <pre class="bg-light p-3 small overflow-auto"><code>WITH m AS (
-  SELECT embedding_hv FROM public.period_embeddings
-  WHERE period = 'month' AND is_combined = TRUE AND period_key = :key
-)
-SELECT topic
-FROM public.topic_labels t, m
-ORDER BY t.emb &lt;=&gt; m.embedding_hv
-LIMIT 5;</code></pre>
-                    </div>
-                    <div class="mb-4">
-                        <h4 class="h6">C) Spot big month-to-month jumps</h4>
-                    <pre class="bg-light p-3 small overflow-auto"><code>WITH months AS (
-  SELECT period_key,
-         to_date(period_key || '-01', 'YYYY-MM-DD') AS d,
-         embedding_hv
-  FROM public.period_embeddings
-  WHERE period = 'month' AND is_combined = TRUE
-    AND period_key BETWEEN '1850-01' AND '1859-12'
-),
-seq AS (
-  SELECT *, LAG(embedding_hv) OVER (ORDER BY d) AS prev_hv
-  FROM months
-)
-SELECT period_key,
-       (prev_hv &lt;=&gt; embedding_hv) AS dist_to_prev
-FROM seq
-WHERE prev_hv IS NOT NULL
-ORDER BY d;</code></pre>
-                        <p class="small text-muted mb-0">Highest cosine distances often mark regime changes (for example, <code>1854-03/04</code> or <code>1857-05/06</code>).</p>
-                    </div>
+                    <div id="helperDocsResult" class="mb-3"></div>
+                    <div id="helperTopicsResult" class="mb-3"></div>
+                    <div id="helperDriftResult"></div>
+                </div>
+            </div>
+            <div class="card shadow-sm mt-3">
+                <div class="card-body">
                     <h3 class="h6 mb-2">UMAP tuning tips</h3>
                     <ul class="small">
                         <li>Use <code>metric='cosine'</code> and <code>init='pca'</code>.</li>
@@ -414,7 +567,7 @@ ORDER BY d;</code></pre>
                     <ul class="small mb-0">
                         <li>Draw a faint line through months in chronological order to highlight big jumps.</li>
                         <li>Add a toggle to color by cluster (e.g., KMeans on the original vectors or their PCA-50 reduction).</li>
-                        <li>On hover, surface the top three nearest topics (query B) and a few representative articles (query A).</li>
+                        <li>On hover, surface the top three nearest topics and a few representative articles.</li>
                     </ul>
                 </div>
             </div>
@@ -442,8 +595,17 @@ ORDER BY d;</code></pre>
         const summaryEl = document.getElementById('summary');
         const detailContent = document.getElementById('detailContent');
         const resetButton = document.getElementById('resetButton');
+        const helperIntro = document.getElementById('helperIntro');
+        const helperDocsButton = document.getElementById('helperDocsButton');
+        const helperTopicsButton = document.getElementById('helperTopicsButton');
+        const helperDriftButton = document.getElementById('helperDriftButton');
+        const helperDocsResult = document.getElementById('helperDocsResult');
+        const helperTopicsResult = document.getElementById('helperTopicsResult');
+        const helperDriftResult = document.getElementById('helperDriftResult');
         let latestPayload = null;
         let isLoading = false;
+        let selectedItem = null;
+        let selectionStamp = 0;
 
         const escapeHtml = (value) => {
             const str = value == null ? '' : String(value);
@@ -459,6 +621,226 @@ ORDER BY d;</code></pre>
             });
         };
 
+        const defaultHelperMessage = helperIntro ? helperIntro.textContent : 'Select a point in the chart to unlock quick lookups.';
+        const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+
+        const clearHelperOutputs = () => {
+            if (helperDocsResult) {
+                helperDocsResult.innerHTML = '';
+            }
+            if (helperTopicsResult) {
+                helperTopicsResult.innerHTML = '';
+            }
+            if (helperDriftResult) {
+                helperDriftResult.innerHTML = '';
+            }
+        };
+
+        const setHelpersEnabled = (enabled, options = {}) => {
+            const {clearOutputs = false} = options;
+            [helperDocsButton, helperTopicsButton, helperDriftButton].forEach((btn) => {
+                if (!btn) {
+                    return;
+                }
+                btn.disabled = !enabled;
+            });
+            if (helperIntro) {
+                helperIntro.textContent = enabled
+                    ? 'Choose an action to pull confirming evidence from the database.'
+                    : defaultHelperMessage;
+            }
+            if (!enabled || clearOutputs) {
+                clearHelperOutputs();
+            }
+        };
+
+        const formatPeriodLabel = (period, startDate, fallback) => {
+            if (typeof startDate !== 'string' || startDate.length < 4) {
+                return fallback || '?';
+            }
+            const year = startDate.slice(0, 4);
+            if (period === 'month' && startDate.length >= 7) {
+                const monthIndex = parseInt(startDate.slice(5, 7), 10) - 1;
+                if (!Number.isNaN(monthIndex) && monthIndex >= 0 && monthIndex < monthNames.length) {
+                    return `${monthNames[monthIndex]} ${year}`;
+                }
+            }
+            if (period === 'year') {
+                return year;
+            }
+            return fallback || startDate;
+        };
+
+        const renderDocsResult = (docs, selection) => {
+            if (!Array.isArray(docs) || docs.length === 0) {
+                return '<div class="small text-muted">No articles found for this period.</div>';
+            }
+            let html = '';
+            docs.forEach((doc) => {
+                const metaParts = [];
+                if (doc.date) {
+                    metaParts.push(doc.date);
+                }
+                if (doc.pubname) {
+                    metaParts.push(doc.pubname);
+                }
+                if (doc.id != null) {
+                    metaParts.push(`ID ${doc.id}`);
+                }
+                const metaLine = metaParts.length ? `<div class="small text-muted">${escapeHtml(metaParts.join(' · '))}</div>` : '';
+                const summaryText = doc.summary ? escapeHtml(doc.summary) : 'No summary available.';
+                const similarityText = typeof doc.similarity === 'number'
+                    ? `Cosine similarity ${(doc.similarity).toFixed(3)}`
+                    : 'Cosine similarity unavailable';
+                html += `
+                    <div class="border rounded-3 p-2 mb-2 bg-white">
+                        ${metaLine}
+                        <div class="small mt-1">${summaryText}</div>
+                        <div class="small text-muted mt-1">${escapeHtml(similarityText)}</div>
+                    </div>
+                `;
+            });
+            if (selection) {
+                const corpusLabel = selection.is_combined
+                    ? 'combined corpus'
+                    : (selection.pubname ? selection.pubname : 'selected publication');
+                html = `<div class="small text-muted mb-2">Top matches within the ${escapeHtml(corpusLabel)}.</div>${html}`;
+            }
+            return html;
+        };
+
+        const renderTopicsResult = (topics) => {
+            if (!Array.isArray(topics) || topics.length === 0) {
+                return '<div class="small text-muted">No curated topics matched this period.</div>';
+            }
+            let html = '<ul class="list-group list-group-flush small">';
+            topics.forEach((topic) => {
+                const similarityText = typeof topic.similarity === 'number'
+                    ? `${(topic.similarity * 100).toFixed(1)}% similarity`
+                    : 'Similarity unavailable';
+                html += `
+                    <li class="list-group-item px-2 py-2">
+                        <div class="fw-semibold">${escapeHtml(topic.topic || 'Untitled topic')}</div>
+                        <div class="text-muted">${escapeHtml(similarityText)}</div>
+                    </li>
+                `;
+            });
+            html += '</ul>';
+            return html;
+        };
+
+        const renderDriftResult = (data, selection) => {
+            if (!data || (!data.prev && !data.next)) {
+                return '<div class="small text-muted">No neighboring periods were found for this selection.</div>';
+            }
+            const segments = [];
+            if (data.prev) {
+                const prevLabel = formatPeriodLabel(selection ? selection.period : null, data.prev.start, data.prev.period_key);
+                const distanceText = typeof data.prev.distance === 'number'
+                    ? `Cosine distance ${(data.prev.distance).toFixed(3)}`
+                    : 'Cosine distance unavailable';
+                segments.push(`<div><strong>Previous:</strong> ${escapeHtml(prevLabel)} <span class="text-muted">(${escapeHtml(distanceText)})</span></div>`);
+            } else {
+                segments.push('<div class="text-muted">No previous period available.</div>');
+            }
+            if (data.next) {
+                const nextLabel = formatPeriodLabel(selection ? selection.period : null, data.next.start, data.next.period_key);
+                const distanceText = typeof data.next.distance === 'number'
+                    ? `Cosine distance ${(data.next.distance).toFixed(3)}`
+                    : 'Cosine distance unavailable';
+                segments.push(`<div><strong>Next:</strong> ${escapeHtml(nextLabel)} <span class="text-muted">(${escapeHtml(distanceText)})</span></div>`);
+            } else {
+                segments.push('<div class="text-muted">No next period available.</div>');
+            }
+            return `<div class="small">${segments.join('')}</div>`;
+        };
+
+        const runHelper = async (type) => {
+            if (!selectedItem) {
+                return;
+            }
+            const buttonMap = {
+                docs: helperDocsButton,
+                topics: helperTopicsButton,
+                drift: helperDriftButton,
+            };
+            const resultMap = {
+                docs: helperDocsResult,
+                topics: helperTopicsResult,
+                drift: helperDriftResult,
+            };
+            const button = buttonMap[type];
+            const container = resultMap[type];
+            if (!button || !container) {
+                return;
+            }
+
+            const selectionSnapshot = selectedItem;
+            const currentStamp = selectionStamp;
+
+            button.disabled = true;
+            container.innerHTML = '<div class="small text-muted">Loading…</div>';
+
+            const params = new URLSearchParams();
+            const periodValue = selectionSnapshot.period || (latestPayload ? latestPayload.period : 'year');
+            params.set('period', periodValue || 'year');
+            params.set('period_key', selectionSnapshot.period_key || '');
+            params.set('aggregation', selectionSnapshot.is_combined ? 'combined' : 'per_pub');
+            if (!selectionSnapshot.is_combined && selectionSnapshot.pubname) {
+                params.set('pubname', selectionSnapshot.pubname);
+            }
+            if (type === 'docs') {
+                params.set('limit', '10');
+            }
+            if (type === 'topics') {
+                params.set('limit', '5');
+            }
+
+            let actionName = '';
+            if (type === 'docs') {
+                actionName = 'nearest_docs';
+            } else if (type === 'topics') {
+                actionName = 'topic_labels';
+            } else if (type === 'drift') {
+                actionName = 'drift';
+            } else {
+                button.disabled = false;
+                return;
+            }
+
+            try {
+                const response = await fetch(`theme_drift.php?action=${actionName}&${params.toString()}`);
+                if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`);
+                }
+                const payload = await response.json();
+                if (!payload.ok) {
+                    throw new Error(payload.error || 'Unknown error');
+                }
+                if (currentStamp !== selectionStamp) {
+                    return;
+                }
+                if (type === 'docs') {
+                    container.innerHTML = renderDocsResult(payload.docs || [], selectionSnapshot);
+                } else if (type === 'topics') {
+                    container.innerHTML = renderTopicsResult(payload.topics || []);
+                } else if (type === 'drift') {
+                    container.innerHTML = renderDriftResult(payload, selectionSnapshot);
+                }
+            } catch (err) {
+                if (currentStamp !== selectionStamp) {
+                    return;
+                }
+                container.innerHTML = `<div class="text-danger small">${escapeHtml(err && err.message ? err.message : 'Failed to load helper data.')}</div>`;
+            } finally {
+                if (currentStamp === selectionStamp) {
+                    button.disabled = false;
+                }
+            }
+        };
+
+        setHelpersEnabled(false);
+
         const updateAggregationState = () => {
             const isCombined = aggregationSelect.value !== 'per_pub';
             pubnameSelect.disabled = isCombined;
@@ -469,6 +851,9 @@ ORDER BY d;</code></pre>
 
         const resetDetail = () => {
             detailContent.innerHTML = 'Click a point in the chart to inspect its metadata.';
+            selectedItem = null;
+            selectionStamp += 1;
+            setHelpersEnabled(false);
         };
 
         const updateSummary = (payload) => {
@@ -611,16 +996,29 @@ ORDER BY d;</code></pre>
                 if (!item) {
                     return;
                 }
+                const selection = {
+                    id: item.id != null ? item.id : null,
+                    period_key: item.period_key || '',
+                    period_start: item.period_start || null,
+                    period_end: item.period_end || null,
+                    label: item.label || item.period_start || 'Selected period',
+                    is_combined: Boolean(item.is_combined),
+                    pubname: item.pubname || null,
+                    period: payload.period || 'year',
+                };
+                selectionStamp += 1;
+                selectedItem = selection;
+                setHelpersEnabled(true, {clearOutputs: true});
                 const publication = item.is_combined ? 'Combined corpus' : (item.pubname || 'Unknown publication');
                 detailContent.innerHTML = `
-                    <div><strong>${escapeHtml(item.label || item.period_start || 'Selected period')}</strong></div>
+                    <div><strong>${escapeHtml(selection.label)}</strong></div>
                     <div class="small text-muted">${escapeHtml(publication)}</div>
                     <hr>
-                    <div><strong>Period:</strong> ${escapeHtml(item.period_start || '?')} → ${escapeHtml(item.period_end || '?')}</div>
+                    <div><strong>Period:</strong> ${escapeHtml(selection.period_start || '?')} → ${escapeHtml(selection.period_end || '?')}</div>
                     <div><strong>Articles:</strong> ${item.article_count ? item.article_count.toLocaleString() : 'n/a'}</div>
                     <div><strong>Tokens:</strong> ${item.token_count ? item.token_count.toLocaleString() : 'n/a'}</div>
                     <div><strong>Model:</strong> ${escapeHtml(item.model || 'unknown')} &middot; dim ${item.dim || 'n/a'}</div>
-                    <div><strong>Database key:</strong> ${escapeHtml(item.period_key || String(item.id || '?'))}</div>
+                    <div><strong>Database key:</strong> ${escapeHtml(selection.period_key || String(item.id || '?'))}</div>
                 `;
             });
         };
@@ -678,6 +1076,22 @@ ORDER BY d;</code></pre>
                 isLoading = false;
             }
         };
+
+        if (helperDocsButton) {
+            helperDocsButton.addEventListener('click', () => {
+                runHelper('docs');
+            });
+        }
+        if (helperTopicsButton) {
+            helperTopicsButton.addEventListener('click', () => {
+                runHelper('topics');
+            });
+        }
+        if (helperDriftButton) {
+            helperDriftButton.addEventListener('click', () => {
+                runHelper('drift');
+            });
+        }
 
         form.addEventListener('submit', (event) => {
             event.preventDefault();


### PR DESCRIPTION
## Summary
- add backend helper endpoints that return nearest documents, curated topics, and neighbor drift data for the selected period
- replace the static SQL helper card with interactive buttons that fetch and render helper data in the UI

## Testing
- php -l theme_drift.php

------
https://chatgpt.com/codex/tasks/task_e_68d00314df0c832995fd9338b839fc60