### PR TITLE
Guard Plotly drag mode changes until plot renders

### DIFF
--- a/theme_drift.php
+++ b/theme_drift.php
@@ -1437,11 +1437,18 @@ if ($defaultStartYear > $defaultEndYear) {
         };
 
         const setDragMode = (mode) => {
-            currentDragMode = mode;
-            if (panModeButton) panModeButton.classList.toggle('active', mode === 'pan');
-            if (lassoModeButton) lassoModeButton.classList.toggle('active', mode === 'lasso');
-            if (chartDiv) {
-                Plotly.relayout(chartDiv, { dragmode: mode });
+            const nextMode = mode === 'lasso' ? 'lasso' : 'pan';
+            currentDragMode = nextMode;
+            if (panModeButton) panModeButton.classList.toggle('active', nextMode === 'pan');
+            if (lassoModeButton) lassoModeButton.classList.toggle('active', nextMode === 'lasso');
+            if (
+                hasRendered &&
+                chartDiv &&
+                typeof Plotly !== 'undefined' &&
+                typeof Plotly.relayout === 'function' &&
+                chartDiv._fullLayout
+            ) {
+                Plotly.relayout(chartDiv, { dragmode: nextMode });
             }
         };
 


### PR DESCRIPTION
## Summary
- guard drag mode toggles so they only call Plotly.relayout after the chart has rendered
- default the stored drag mode to pan while still updating UI button state when the plot is not yet ready

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0157b550483299ccba085a791704f