### PR TITLE
Fix hover interactions in theme drift plot

### DIFF
--- a/theme_drift.php
+++ b/theme_drift.php
@@ -1553,7 +1553,7 @@ if ($defaultStartYear > $defaultEndYear) {
                 mode: 'markers',
                 x: xs,
                 y: ys,
-                hoverinfo: 'skip',
+                hovertemplate: '<extra></extra>',
                 marker,
                 customdata: payload.items.map((item, idx) => [idx, item.period_key || '', item.period_start || '', item.period_end || ''])
             };


### PR DESCRIPTION
## Summary
- ensure Plotly scatter trace fires hover and click events by replacing hoverinfo skip with an empty hover template

## Testing
- php -l theme_drift.php

------
https://chatgpt.com/codex/tasks/task_e_68d018d80ec08329ae850d43cf1d234c